### PR TITLE
Update CalendarViewContainer.js

### DIFF
--- a/src/modules/calendar/CalendarViewContainer.js
+++ b/src/modules/calendar/CalendarViewContainer.js
@@ -10,8 +10,8 @@ export default compose(
     state => ({
       items: state.calendar.items,
     }),
-    dispatch => ({
-      loadItems: items => dispatch(loadItems(items)),
-    }),
+    {
+      loadItems,
+    },
   ),
 )(CalendarScreen);


### PR DESCRIPTION
Here and in other components I'd suggest using this shorter syntax, which is equivalent of original.