### PR TITLE
Minor Fixes + NavigationService & custom DrawerNavigator support

### DIFF
--- a/src/modules/home/HomeView.js
+++ b/src/modules/home/HomeView.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   StyleSheet,
   View,
+  Image,
   TouchableOpacity,
   ImageBackground,
 } from 'react-native';
@@ -29,9 +30,11 @@ export default function HomeScreen({ isExtended, setIsExtended }) {
         resizeMode="cover"
       >
         <View style={styles.section}>
-          <Text size={20} white>
-            Home
-          </Text>
+          <Image
+            source={require('../../../assets/images/white-logo.png')}
+            resizeMode="contain"
+            style={styles.logoImg}
+          />
         </View>
         <View style={styles.section}>
           <Text color="#19e7f7" size={15}>
@@ -101,6 +104,10 @@ const styles = StyleSheet.create({
   description: {
     padding: 15,
     lineHeight: 25,
+  },
+  logoImg: {
+    marginTop: 10,
+    width: 250,
   },
   titleDescription: {
     color: '#19e7f7',

--- a/src/modules/navigation/CustomDrawer.js
+++ b/src/modules/navigation/CustomDrawer.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import { Text, StyleSheet, View, ImageBackground } from 'react-native';
+import { ScrollView, SafeAreaView } from 'react-navigation';
+import { Drawer } from 'react-native-paper';
+import NavigationService from './NavigationService';
+
+
+/* eslint-disable-next-line */
+const CustomDrawerContentComponent = props => (
+  <ScrollView>
+    <SafeAreaView style={styles.container} forceInset={{ top: 'always', horizontal: 'never' }}>
+      <ImageBackground source={require('../../../assets/images/topBarBg.png')} style={styles.imageBackground}>
+        <Text style={styles.headerText}>React Native Starter</Text>
+      </ImageBackground>
+      <View style={styles.screenContainer}>
+        <Drawer.Item
+          label="Home"
+          icon="home"
+          style={styles.screenTextStyle}
+          onPress={() => { NavigationService.resetMainNavigator() }}
+        />
+        <Drawer.Item
+          label="Gallery"
+          icon="perm-media"
+          style={styles.screenTextStyle}
+          onPress={() => { NavigationService.goToSubScreen('Dashboard','Gallery') }}
+        />
+        <Drawer.Item
+          label="Calendar"
+          icon="today"
+          style={styles.screenTextStyle}
+          onPress={() => { NavigationService.goToSubScreen('Dashboard','Calendar') }}
+        />
+        <Drawer.Item
+          label="Grids"
+          icon="view-module"
+          style={styles.screenTextStyle}
+          onPress={() => { NavigationService.goToSubScreen('Dashboard','Grids') }}
+        />
+        <Drawer.Item
+          label="Pages"
+          icon="description"
+          style={styles.screenTextStyle}
+          onPress={() => { NavigationService.goToSubScreen('Dashboard','Pages') }}
+        />
+        <Drawer.Item
+          label="Components"
+          icon="settings"
+          style={styles.screenTextStyle}
+          onPress={() => { NavigationService.goToSubScreen('Dashboard','Components') }}
+        />
+      </View>
+    </SafeAreaView>
+  </ScrollView>
+);
+
+export default CustomDrawerContentComponent;
+
+const styles = StyleSheet.create({
+  container: {
+      flex: 1
+  },
+  imageBackground: {
+    flex: 1,
+    width: 300,
+    justifyContent: 'center',
+    height: 75,
+    alignItems: 'center',
+  },
+  headerContainer: {
+      height: 150,
+  },
+  headerText: {
+      color: '#fff8f8',
+      fontSize: 25,
+  },
+  screenContainer: {
+      paddingTop: 20
+  },
+  screenStyle: {
+      height: 30,
+      marginTop: 2,
+      flexDirection: 'row',
+      alignItems: 'center'
+  },
+  screenTextStyle:{
+      fontSize: 20,
+      marginLeft: 20
+  },
+});

--- a/src/modules/navigation/MainTabNavigator.js
+++ b/src/modules/navigation/MainTabNavigator.js
@@ -56,17 +56,19 @@ const styles = StyleSheet.create({
   },
 });
 
-export default createBottomTabNavigator(
+const bottomTabNav = createBottomTabNavigator(
   {
     Home: {
       screen: HomeScreen,
       navigationOptions: {
+        title: "Home",
         header: null,
       },
     },
     Calendar: {
       screen: CalendarScreen,
       navigationOptions: {
+        title: "Calendar",
         header: (
           <View style={styles.headerContainer}>
             <Image style={styles.headerImage} source={hederBackground} />
@@ -78,6 +80,7 @@ export default createBottomTabNavigator(
     Grids: {
       screen: GridsScreen,
       navigationOptions: {
+        title: "Grids",
         header: (
           <View style={styles.headerContainer}>
             <Image style={styles.headerImage} source={hederBackground} />
@@ -89,6 +92,7 @@ export default createBottomTabNavigator(
     Pages: {
       screen: PagesScreen,
       navigationOptions: {
+        title: "Pages",
         header: (
           <View style={styles.headerContainer}>
             <Image style={styles.headerImage} source={hederBackground} />
@@ -100,6 +104,7 @@ export default createBottomTabNavigator(
     Components: {
       screen: ComponentsScreen,
       navigationOptions: {
+        title: "Components",
         header: (
           <View style={styles.headerContainer}>
             <Image style={styles.headerImage} source={hederBackground} />
@@ -161,3 +166,25 @@ export default createBottomTabNavigator(
     },
   },
 );
+
+bottomTabNav.navigationOptions = ({ navigation }) => {
+  const { routeName } = navigation.state.routes[navigation.state.index];
+
+  // Set the headerTitle to the current route name
+  const currentRoute = routeName;
+  let headerTitle;
+
+  switch (currentRoute) {
+    case 'Home':
+      headerTitle = "React Native Starter";
+      break;
+    default:
+      headerTitle = currentRoute;
+  }
+
+  return {
+    headerTitle
+  };
+};
+
+export default bottomTabNav;

--- a/src/modules/navigation/NavigationService.js
+++ b/src/modules/navigation/NavigationService.js
@@ -1,0 +1,62 @@
+/* NavigationService for ReactNavigation v3
+/ For use in navigating in nested components without passing navigation prop
+/ See: https://reactnavigation.org/docs/en/navigating-without-navigation-prop.html
+*/
+
+import { NavigationActions, DrawerActions } from 'react-navigation';
+
+let _navigator;
+
+function setTopLevelNavigator(navigatorRef) {
+  _navigator = navigatorRef;
+}
+
+function goToSubScreen(mainRoute, subRoute) {
+  const navigateAction = NavigationActions.navigate({
+    routeName: mainRoute,
+    params: {},
+    action: NavigationActions.navigate({ routeName: subRoute }),
+  });
+  _navigator.dispatch(navigateAction);
+}
+
+function resetMainNavigator() {
+  const navigateAction = NavigationActions.navigate({
+    routeName: 'Main',
+    params: {},
+    action: NavigationActions.navigate({ routeName: 'Home' }),
+  });
+  _navigator.dispatch(navigateAction);
+  _navigator.dispatch(DrawerActions.closeDrawer());
+
+}
+
+function openDrawer(){
+  _navigator.dispatch(DrawerActions.openDrawer());
+}
+
+function goBack() {
+  _navigator.dispatch(
+    NavigationActions.back()
+  );
+}
+
+function navigate(routeName, params) {
+  _navigator.dispatch(
+    NavigationActions.navigate({
+      routeName,
+      params,
+    })
+  );
+}
+
+// add other navigation functions that you need and export them
+
+export default {
+  navigate,
+  setTopLevelNavigator,
+  openDrawer,
+  goBack,
+  resetMainNavigator,
+  goToSubScreen,
+};

--- a/src/modules/navigation/Navigator.js
+++ b/src/modules/navigation/Navigator.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 // import AuthScreen from '../containers/AuthScreen';
 import AppNavigator from './RootNavigation';
+import NavigationService from './NavigationService';
 
 export default function NavigatorView() {
   // if (authState.isLoggedIn || authState.hasSkippedLogin) {
@@ -9,5 +10,11 @@ export default function NavigatorView() {
   // }
   // return <AuthScreen />;
 
-  return <AppNavigator />;
+  return (
+    <AppNavigator
+      ref={navigatorRef => {
+        NavigationService.setTopLevelNavigator(navigatorRef);
+      }}
+    />
+  )
 }

--- a/src/modules/navigation/RootNavigation.js
+++ b/src/modules/navigation/RootNavigation.js
@@ -1,7 +1,9 @@
 import React from 'react';
-import { Image, TouchableOpacity } from 'react-native';
-import { createAppContainer, createStackNavigator } from 'react-navigation';
-
+import { Image } from 'react-native';
+import { createAppContainer, createStackNavigator, createSwitchNavigator, createDrawerNavigator } from 'react-navigation';
+import Icon from 'react-native-vector-icons/Entypo';
+import NavigationService from './NavigationService';
+import CustomDrawer from './CustomDrawer';
 import MainTabNavigator from './MainTabNavigator';
 
 import GalleryScreen from '../gallery/GalleryViewContainer';
@@ -24,8 +26,7 @@ const stackNavigator = createStackNavigator(
     Main: {
       screen: MainTabNavigator,
       navigationOptions: () => ({
-        title: 'React Native Starter',
-        headerLeft: null,
+        title: null,
         headerBackground: (
           <Image
             style={{ flex: 1, width: '100%' }}
@@ -45,6 +46,14 @@ const stackNavigator = createStackNavigator(
       screen: GalleryScreen,
       navigationOptions: {
         title: 'Gallery',
+        headerLeft: (
+          <Icon
+            style={{ color: '#fff', paddingLeft: 10 }}
+            onPress={() => NavigationService.goBack()}
+            name="arrow-bold-left"
+            size={30}
+          />
+        ),
       },
     },
     Article: {
@@ -83,7 +92,7 @@ const stackNavigator = createStackNavigator(
       },
       headerBackground: (
         <Image
-          style={{ flex: 1 }}
+          style={{ flex: 1, width: '100%' }}
           source={headerBackground}
           resizeMode="cover"
         />
@@ -93,24 +102,41 @@ const stackNavigator = createStackNavigator(
         fontFamily: fonts.primaryRegular,
       },
       headerTintColor: '#222222',
-      headerLeft: props => (
-        <TouchableOpacity
-          onPress={props.onPress}
-          style={{
-            paddingLeft: 25,
-          }}
-        >
-          <Image
-            source={require('../../../assets/images/icons/arrow-back.png')}
-            resizeMode="contain"
-            style={{
-              height: 20,
-            }}
-          />
-        </TouchableOpacity>
+      headerLeft: (
+        <Icon
+          style={{ color: '#fff', paddingLeft: 10 }}
+          onPress={() => NavigationService.openDrawer()}
+          name="menu"
+          size={30}
+        />
       ),
     }),
   },
 );
 
-export default createAppContainer(stackNavigator);
+const AppDrawerNavigator = createDrawerNavigator({
+  Dashboard: {
+    screen: stackNavigator,
+    navigationOptions: {
+      drawerLabel: 'Home',
+      drawerIcon: (
+        <Icon
+          style={{ paddingLeft: 10 }}
+          name="menu"
+          size={30}
+        />
+      ),
+    },
+  },
+}, {
+  contentComponent: CustomDrawer,
+  drawerWidth: 300
+});
+
+const AppSwitchNavigator = createSwitchNavigator({
+  Dashboard: { screen: AppDrawerNavigator },
+  Gallery: { screen: GalleryScreen },
+});
+
+const MainAppContainer = createAppContainer(AppSwitchNavigator);
+export default MainAppContainer;

--- a/src/modules/navigation/RootNavigation.js
+++ b/src/modules/navigation/RootNavigation.js
@@ -28,7 +28,7 @@ const stackNavigator = createStackNavigator(
         headerLeft: null,
         headerBackground: (
           <Image
-            style={{ flex: 1 }}
+            style={{ flex: 1, width: '100%' }}
             source={headerBackground}
             resizeMode="cover"
           />


### PR DESCRIPTION
My first PR, so bear with me. 

1. A minor fix to the header image making it 100% width as it was short on most iOS & Android devices.
<img width="579" alt="Screen Shot 2019-03-26 at 12 45 44 AM" src="https://user-images.githubusercontent.com/16378407/54974169-76837d80-4f69-11e9-81a5-ff70f15cd3da.png">

2. RNS utilizing React Navigation v3 has a TabNavigator nested in a StackNavigator, this is fine however by default, it's behavior is to override the TabNavigator titles. If you switch tabs, the title never changes from 'React Native Starter'. I modified TabNavigator, which is now exported as a function, to changes titles on a "switch" case. Users can easily modify their own logic here. 

3. Swapped the "Home" text in HomeView with the RNS logo.

4. Added a custom NavigationService for linking to different screens inside of any app component without passing props. 

Users can

```
import NavigationService from './NavigationService';

        <Drawer.Item
          label="Home"
          icon="home"
          style={styles.screenTextStyle}
          onPress={() => { NavigationService.resetMainNavigator() }}
        />
        <Drawer.Item
          label="Gallery"
          icon="perm-media"
          style={styles.screenTextStyle}
          onPress={() => { NavigationService.goToSubScreen('Dashboard','Gallery') }}
        />
```
NavigationService can be easily modified to include custom functions. It currently contains a nested navigation switch screen function, resetting to home screen, open/close drawer navigator.

Additionally, I added support for DrawerNavigator. In many cases, apps use DrawerNavigator and since RNS is IMHO the best starter template, I gave a shot at including it. The CustomDrawer component utilizes react-native-paper, which RNS already includes. CustomDrawer also references the new NavigationService. 

<img width="347" alt="Screen Shot 2019-03-26 at 1 59 42 AM" src="https://user-images.githubusercontent.com/16378407/54974602-f52cea80-4f6a-11e9-8eee-45577f6c9670.png">
