### PR TITLE
Update detox version to make project compatible with Xcode 10.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.5.0",
     "danger": "^7.0.2",
-    "detox": "^9.1.2",
+    "detox": "^12.1.1",
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.7.0",
     "eslint": "^5.9.0",


### PR DESCRIPTION
Update detox version to make project compatible with Xcode 10.12. Or the `yarn run:ios` command may fail.